### PR TITLE
test(e2e): update registration flow to include email field

### DIFF
--- a/uni-chatbot/e2e_tests.py
+++ b/uni-chatbot/e2e_tests.py
@@ -173,6 +173,7 @@ def test_comprehensive_features():
                 take_screenshot(page, '07_registration_page.png', 'Registration page')
 
                 page.fill('#id_username', test_username)
+                page.fill('#id_email', f"{test_username}@example.com") 
                 page.fill('#id_password1', test_password)
                 page.fill('#id_password2', test_password)
                 print("✓ Registration form filled")


### PR DESCRIPTION
This PR updates the E2E test to match the new registration form (which now includes an email field). The test flow was failing because it attempted registration without filling the email input. Adding the missing step fixes the issue.
